### PR TITLE
Fix streaming error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Imports:
     jsonlite,
     logger,
     pbapply,
-    crayon
+    crayon,
+    progress,
+    curl
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 URL: https://github.com/ertamaki/AskOllama


### PR DESCRIPTION
## Summary
- add a NULL check for parsed streaming chunks

## Testing
- `R CMD check .` *(fails: command not found)*