### PR TITLE
Enhance verbose mode with progress details

### DIFF
--- a/man/ask_ollama.Rd
+++ b/man/ask_ollama.Rd
@@ -61,7 +61,7 @@ ask_ollama(
 
 \item{web_content_limit}{Maximum number of characters to be fetched.}
 
-\item{verbose}{Logical. If \code{TRUE}, shows detailed request/response information.}
+\item{verbose}{Logical. If \code{TRUE}, shows detailed request/response information and displays progress bars.}
 }
 \value{
 Character string containing the model's response


### PR DESCRIPTION
## Summary
- show a simple progress bar while executing API requests
- add helper to print detailed request info
- display token progress when streaming in verbose mode
- document verbose improvements

## Testing
- `git status --short`